### PR TITLE
PO-464: Stopped loader if loading apps failed

### DIFF
--- a/src/pages/settings/apps/index.js
+++ b/src/pages/settings/apps/index.js
@@ -119,6 +119,7 @@ export class Apps extends Base {
 
     async loadApps() {
         try {
+            this.apps = [];
             let data = await this.api.getApps();
             let numberOfPlugins = this.apps.length;
             data.plugins = data.plugins.filter(({ name }) => !!name);
@@ -140,6 +141,7 @@ export class Apps extends Base {
             }
             this.appsLoading = false;
         } catch (error) {
+            this.appsLoading = false;
             Logger.error(`Could not load Apps: ${error.message}`);
         }
     }


### PR DESCRIPTION
Seems that infinity loader was related to unhandling error of the `get_plugins` request.