### PR TITLE
disable host checking in dev server

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,6 +75,7 @@ module.exports = ({stage, target, server, coverage} = {}) => ({
     },
     devServer: {
         contentBase: outDir,
+        disableHostCheck: true,
         historyApiFallback: true,
     },
     module: {


### PR DESCRIPTION
Otherwise websockets don't seem to work with `nps debug.cloud` when
connecting to http://localhost:8080.