### PR TITLE
remove deprecated /check_alive api call

### DIFF
--- a/src/components/api-cloud.js
+++ b/src/components/api-cloud.js
@@ -100,12 +100,6 @@ export class APICloud extends APIGateway {
         return this._executeV1('base/installations/${installationId}/gateways/openmotics/${gatewayId}/factory_reset', installationId, payload, true, options);
     }
 
-    async checkAlive(options) {
-        options = options || {};
-        let data = await this._executeV1('base/installations/${installationId}/check_alive', undefined, {}, true, options);
-        return data.data
-    }
-
     async getInstallationSettings(options) {
         options = options || {};
         return await this._executeV1('base/installations/${installationId}/settings', undefined, {}, true, options);

--- a/src/containers/installation.js
+++ b/src/containers/installation.js
@@ -68,12 +68,12 @@ export class Installation extends BaseObject {
     async checkAlive(timeout) {
         try {
             this.aliveLoading = true;
-            let data = await this.api.checkAlive({
+            let data = await this.api.getGateways({
                 ignoreConnection: true,
                 installationId: this.id,
                 timeout: timeout
             });
-            this.alive = data['alive'];
+            this.alive = data.data.every(gateway => gateway.online);
         } catch (error) {
             this.alive = false;
         } finally {


### PR DESCRIPTION
This still makes the entire portal unusable when a single gateway is
offline.