### PR TITLE
don't overwrite sensor status values

### DIFF
--- a/src/pages/setup/sensors/index.js
+++ b/src/pages/setup/sensors/index.js
@@ -65,7 +65,9 @@ export class Sensors extends Base {
                 for (let sensor of this.sensors) {
                     sensors.forEach(({ local_id, physical_quantity, status }) => {
                         if (local_id === sensor.id) {
-                            sensor[physical_quantity] = (status || {})[physical_quantity];
+                            if (Object.keys(status || {}).contains(physical_quantity)) {
+                                sensor[physical_quantity] = (status || {})[physical_quantity];
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
With the v1.1 api sensors only contain a single physical quanitity so
for a single entry from get_sensor_configurations there will be a
separate sensor for temperature, humidity and brightness.