### PR TITLE
create maintenance connection using gateway id

### DIFF
--- a/src/components/websocket-maintenance.js
+++ b/src/components/websocket-maintenance.js
@@ -27,6 +27,9 @@ export class MaintenanceWebSocketClient extends WebSocketClient {
 
     async specifyChannel() {
         if (this.shared.target === 'cloud' && this.shared.installation !== undefined) {
+            if (this.shared.openMoticGateway !== undefined) {
+                return this.send(`connect gateway ${this.shared.openMoticGateway.id}`);
+            }
             return this.send(`connect ${this.shared.installation.id}`);
         }
     }


### PR DESCRIPTION
Sending the direct installation id doesn't work on multi-gateway
installations.