### PR TITLE
FE-607 only handle thermostat events on mouseup

### DIFF
--- a/src/pages/cloud/thermostats/index.js
+++ b/src/pages/cloud/thermostats/index.js
@@ -47,7 +47,7 @@ export class Thermostats extends Base {
             return this.processEvent(message);
         };
         this.refresher = new Refresher(async () => {
-            if (this.installationHasUpdated || this.gatewayHasUpdated) {
+            if (this.installationHasUpdated) {
                 this.initVariables();
             }
         }, 60000);
@@ -62,7 +62,6 @@ export class Thermostats extends Base {
         this.allThermostats = [];
         this.prevUnitsData = [];
         this.installationHasUpdated = false;
-        this.gatewayHasUpdated = false;
         this.globalThermostats = [];
         this.presets = ['AUTO', 'AWAY', 'VACATION', 'PARTY'];
         await this.loadThermostats();
@@ -280,11 +279,6 @@ export class Thermostats extends Base {
 
     installationUpdated() {
         this.installationHasUpdated = true;
-        this.refresher.run();
-    }
-
-    gatewayUpdated() {
-        this.gatewayHasUpdated = true;
         this.refresher.run();
     }
 

--- a/src/pages/cloud/thermostats/index.js
+++ b/src/pages/cloud/thermostats/index.js
@@ -172,7 +172,7 @@ export class Thermostats extends Base {
             }
             const isEqual = this.isArrayEqual(this.prevUnitsData, data);
             if (!isEqual) {
-                setTimeout(() => this.drawThermostats(), 100);
+                setTimeout(() => this.drawThermostats(this.temperatureThermostats), 100);
             }
             this.prevUnitsData = data;
         } catch (error){
@@ -218,15 +218,15 @@ export class Thermostats extends Base {
         this.temperatureThermostats.forEach(thermostat => {
             thermostat.status.preset = preset.toUpperCase();
         });
-        this.drawThermostats();
+        this.drawThermostats(this.temperatureThermostats);
     }
 
     onGroupChange() {
-        setTimeout(() => this.drawThermostats(), 100);
+        setTimeout(() => this.drawThermostats(this.temperatureThermostats), 100);
     }
 
-    drawThermostats() {
-        this.temperatureThermostats.forEach(thermostat => {
+    drawThermostats(thermostats) {
+        thermostats.forEach(thermostat => {
             const { id, name, configuration, status, currentSetpoint, actualTemperature } = thermostat;
             const options = {
                 id: `cUIc_${id}`,
@@ -258,12 +258,12 @@ export class Thermostats extends Base {
         switch (event.type) {
             case 'THERMOSTAT_CHANGE': {
                 const { id, status } = event.data;
-                const index = this.temperatureThermostats.findIndex(thermostat => thermostat.id === id);
-                if (index !== -1) {
-                    this.temperatureThermostats[index].status = status;
-                    this.temperatureThermostats[index].actualTemperature = status.actual_temperature;
-                    this.temperatureThermostats[index].currentSetpoint = status.current_setpoint;
-                    this.drawThermostats();
+                const thermostat = this.temperatureThermostats.find(thermostat => thermostat.id === id);
+                if (thermostat !== undefined) {
+                    thermostat.status = status;
+                    thermostat.actualTemperature = status.actual_temperature;
+                    thermostat.currentSetpoint = status.current_setpoint;
+                    this.drawThermostats([thermostat]);
                 }
                 break;
             }

--- a/src/pages/cloud/thermostats/thermostats-ui.js
+++ b/src/pages/cloud/thermostats/thermostats-ui.js
@@ -6,9 +6,6 @@ $.fn.thermostat_ui = function (options) {
     // ## Variables
     // ##############################
     var element = $(this[0]);
-    element.bind('update', () => (
-        current_model.thermostat.change({ detail: { value: current_model.currentSetpoint }})
-    ));
 
     // ## Data container structure
     //    Contains all exact measurements corresponding with the interface
@@ -43,7 +40,7 @@ $.fn.thermostat_ui = function (options) {
                 return 'n/a';
             }
             return parts[0] + '.' + parts[1];
-        }        
+        }
     };
 
     // ## Colors
@@ -54,7 +51,7 @@ $.fn.thermostat_ui = function (options) {
     var hot_color = options.hot_color;
     var title_color = options.cool_color;
     var font = '"Helvetica Neue", Helvetica, Arial, sans-serif';
-    
+
     // ## Image information
     var icons = {
         flame: { x: 100, y: 95,   w: 22, h: 29 },
@@ -66,7 +63,7 @@ $.fn.thermostat_ui = function (options) {
         vac:   { x: 1,   y: 1199, w: 29, h: 28 },
         party: { x: 339, y: 48,   w: 23, h: 27 }
     };
-    
+
     // ## Variables
     var i;
     var id_offset = 'thui-' + options.id + '-';
@@ -79,7 +76,7 @@ $.fn.thermostat_ui = function (options) {
     var actual_setpoint = options.currentSetpoint;
     var images_loaded = false;
     var model_loaded = false;
-    
+
     // ## Calculate variables
     var ratio = window.hasOwnProperty('devicePixelRatio') ? window.devicePixelRatio : 1;
     var draw_height = options.height;
@@ -96,25 +93,23 @@ $.fn.thermostat_ui = function (options) {
     canvas_element.width = draw_width * ratio;
     canvas_element.height = draw_height * ratio;
     var canvas = $('#' + id_offset + 'canvas');
-    
+
     // ## Mouse handles
     function mousemove(event) {
         coordinates = get_coordinates(event);
         if (dragging) {
             event.preventDefault();
             event.originalEvent.preventDefault();
-            
             draw();
         }
     }
-    
+
     function mousedown(event) {
         coordinates = get_coordinates(event);
         dragging = over_arc(coordinates);
         if (dragging) {
             event.preventDefault();
             event.originalEvent.preventDefault();
-
             actual_setpoint = current_model.currentSetpoint;
             draw();
         }
@@ -128,7 +123,8 @@ $.fn.thermostat_ui = function (options) {
             dragging = false;
             actual_setpoint = current_model.currentSetpoint;
             draw();
-            element.trigger('update');
+
+            current_model.thermostat.change({ detail: { value: actual_setpoint }})
         }
     }
 
@@ -219,7 +215,7 @@ $.fn.thermostat_ui = function (options) {
         context.fillStyle = background_color;
         context.fillRect(0, 0, draw_width, draw_height);
         context.stroke();
-        
+
         current_model.currentSetpoint = new_setpoint;
         var original_rads = temp2relrad(actual_setpoint);
         var current_rads = temp2relrad(current_model.currentSetpoint);


### PR DESCRIPTION
The thermostat_ui elements are only rendered once, which results in
multiple update hooks bound to update events or update events
triggering before the new value for the setpoint has been changed.